### PR TITLE
+ Support for NVIDIA Jetson

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,6 @@ build:manylinux2010 --crosstool_top=//third_party/toolchains/preconfig/ubuntu16.
 
 build -c opt
 build --cxxopt="-std=c++14"
-build --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0"
 build --auto_output_filter=subpackages
 build --copt="-Wall" --copt="-Wno-sign-compare"
 build --linkopt="-lrt -lm"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,8 @@ workspace(name = "reverb")
 # *WARNING* If using the REVERB_PROTOC_VERSION environment variable, sha256
 # checking is disabled.  Use at your own risk.
 PROTOC_VERSION = "3.9.0"
-PROTOC_SHA256 = "15e395b648a1a6dda8fd66868824a396e9d3e89bc2c8648e3b9ab9801bea5d55"
+PROTOC_x86_SHA256 = "15e395b648a1a6dda8fd66868824a396e9d3e89bc2c8648e3b9ab9801bea5d55"
+PROTOC_aarch64_SHA256 = "7877fee5793c3aafd704e290230de9348d24e8612036f1d784c8863bc790082e"
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -83,4 +84,4 @@ cc_tf_configure()
 
 reverb_python_deps()
 
-reverb_protoc_deps(version = PROTOC_VERSION, sha256 = PROTOC_SHA256)
+reverb_protoc_deps(version = PROTOC_VERSION, sha256 = [ PROTOC_x86_SHA256, PROTOC_aarch64_SHA256 ])

--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -324,19 +324,29 @@ def reverb_python_deps():
 def _reverb_protoc_archive(ctx):
     version = ctx.attr.version
     sha256 = ctx.attr.sha256
+    arch = ctx.execute(["uname", "-m"]).stdout.strip()
 
     override_version = ctx.os.environ.get("REVERB_PROTOC_VERSION")
     if override_version:
         sha256 = ""
         version = override_version
 
-    urls = [
-        "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-x86_64.zip" % (version, version),
-    ]
-    ctx.download_and_extract(
+    if arch in ["aarch64"]:
+      urls = [
+          "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-aarch_64.zip" % (version, version),
+      ]
+      ctx.download_and_extract(
         url = urls,
-        sha256 = sha256,
-    )
+        sha256 = sha256[1],
+      )
+    else:
+      urls = [
+          "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-x86_64.zip" % (version, version),
+      ]
+      ctx.download_and_extract(
+          url = urls,
+          sha256 = sha256[0],
+      )
 
     ctx.file(
         "BUILD",
@@ -354,7 +364,7 @@ reverb_protoc_archive = repository_rule(
     implementation = _reverb_protoc_archive,
     attrs = {
         "version": attr.string(mandatory = True),
-        "sha256": attr.string(mandatory = True),
+        "sha256": attr.string_list(mandatory = True),
     },
 )
 

--- a/reverb/pip_package/build_pip_package.sh
+++ b/reverb/pip_package/build_pip_package.sh
@@ -20,6 +20,7 @@ function build_wheel() {
   DESTDIR="$2"
   RELEASE_FLAG="$3"
   TF_VERSION_FLAG="$4"
+  CPU_ARCH=$(uname -m)
 
   # Before we leave the top-level directory, make sure we know how to
   # call python.
@@ -32,7 +33,11 @@ function build_wheel() {
   pushd ${TMPDIR} > /dev/null
 
   echo $(date) : "=== Building wheel"
-  "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat manylinux2010_x86_64 > /dev/null
+  if [ "$CPU_ARCH" = "aarch64" ]; then
+    "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} > /dev/null
+  else
+    "${PYTHON_BIN_PATH}" setup.py bdist_wheel ${PKG_NAME_FLAG} ${RELEASE_FLAG} ${TF_VERSION_FLAG} --plat manylinux2010_x86_64 > /dev/null
+  fi
   DEST=${TMPDIR}/dist/
   if [[ ! "$TMPDIR" -ef "$DESTDIR" ]]; then
     mkdir -p ${DESTDIR}


### PR DESCRIPTION
Solution of issue #53.

@ebrevdo @tfboyd

## Build

```bazel
ubuntu@nvidia-01:~/Desktop/Projects/reverb-ok$ bash oss_build.sh --clean true --tf_dep_override "tensorflow==2.5.0" --release --python "3.6"
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
INFO: SHA256 (https://boringssl.googlesource.com/boringssl/+archive/83da28a68f32023fd3b95a8ae94991a07b1f6c62.tar.gz) = ecb10c5dd5bcd38995c931916582873cd4a8ece53097dfe4a801ea7f9011ca6b
DEBUG: Rule 'boringssl' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "ecb10c5dd5bcd38995c931916582873cd4a8ece53097dfe4a801ea7f9011ca6b"
DEBUG: Repository boringssl instantiated at:
  no stack (--record_rule_instantiation_callstack not enabled)
Repository rule http_archive defined at:
  /home/ubuntu/.cache/bazel/_bazel_ubuntu/e258ef7af8c58ec768ec5f3c83562f89/external/bazel_tools/tools/build_defs/repo/http.bzl:336:16: in <toplevel>
INFO: Analyzed 129 targets (67 packages loaded, 8639 targets configured).
INFO: Found 103 targets and 26 test targets...
INFO: From Compiling reverb/cc/rate_limiter.cc:
reverb/cc/rate_limiter.cc: In member function 'std::vector<deepmind::reverb::RateLimiterEvent> deepmind::reverb::RateLimiter::StatsManager::GetEventHistory(absl::lts_2020_09_23::Mutex*, size_t) const':
reverb/cc/rate_limiter.cc:276:7: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
   if (const auto diff = next_event_id_ - min_event_id; diff >= events_.size()) {
       ^~~~~
INFO: From Compiling reverb/cc/table.cc:
reverb/cc/table.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::Table::SampleFlexibleBatch(std::vector<deepmind::reverb::Table::SampledItem>*, int, absl::lts_2020_09_23::Duration)':
reverb/cc/table.cc:227:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status = rate_limiter_->AwaitAndFinalizeSample(&mu_, timeout);
           ^~~~
INFO: From Compiling reverb/cc/support/signature.cc:
reverb/cc/support/signature.cc: In lambda function:
reverb/cc/support/signature.cc:179:3: warning: control reaches end of non-void function [-Wreturn-type]
   };
   ^
INFO: From Compiling reverb/cc/sampler.cc:
reverb/cc/sampler.cc: In member function 'virtual std::pair<long int, absl::lts_2020_09_23::Status> deepmind::reverb::{anonymous}::LocalSamplerWorker::FetchSamples(deepmind::reverb::internal::Queue<std::unique_ptr<deepmind::reverb::Sample> >*, int64_t, absl::lts_2020_09_23::Duration)':
reverb/cc/sampler.cc:343:13: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
         if (status = AsSample(item, &sample); !status.ok()) {
             ^~~~~~
reverb/cc/sampler.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::Sample::AsTrajectory(std::vector<tensorflow::Tensor>*)':
reverb/cc/sampler.cc:791:9: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
     if (int batch_dim = sequences[i + 4].shape().dim_size(0); batch_dim != 1) {
         ^~~
INFO: From Compiling reverb/cc/sampler.cc:
reverb/cc/sampler.cc: In member function 'virtual std::pair<long int, absl::lts_2020_09_23::Status> deepmind::reverb::{anonymous}::LocalSamplerWorker::FetchSamples(deepmind::reverb::internal::Queue<std::unique_ptr<deepmind::reverb::Sample> >*, int64_t, absl::lts_2020_09_23::Duration)':
reverb/cc/sampler.cc:343:13: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
         if (status = AsSample(item, &sample); !status.ok()) {
             ^~~~~~
reverb/cc/sampler.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::Sample::AsTrajectory(std::vector<tensorflow::Tensor>*)':
reverb/cc/sampler.cc:791:9: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
     if (int batch_dim = sequences[i + 4].shape().dim_size(0); batch_dim != 1) {
         ^~~
INFO: From Compiling reverb/cc/trajectory_writer.cc:
reverb/cc/trajectory_writer.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::TrajectoryWriter::CreateItem(absl::lts_2020_09_23::string_view, double, absl::lts_2020_09_23::Span<const deepmind::reverb::TrajectoryColumn>)':
reverb/cc/trajectory_writer.cc:306:9: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
     if (auto status = trajectory[col_idx].Validate(); !status.ok()) {
         ^~~~
reverb/cc/trajectory_writer.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::TrajectoryWriter::ConfigureChunker(int, const std::shared_ptr<deepmind::reverb::ChunkerOptions>&)':
reverb/cc/trajectory_writer.cc:664:7: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
   if (auto it = chunkers_.find(column); it != chunkers_.end()) {
       ^~~~
reverb/cc/trajectory_writer.cc: In lambda function:
reverb/cc/trajectory_writer.cc:144:3: warning: control reaches end of non-void function [-Wreturn-type]
   };
   ^
INFO: From Compiling reverb/cc/reverb_service_impl.cc:
reverb/cc/reverb_service_impl.cc: In member function 'grpc::Status deepmind::reverb::ReverbServiceImpl::InsertStreamInternal(grpc::ServerContext*, grpc::ServerReaderWriterInterface<deepmind::reverb::InsertStreamResponse, deepmind::reverb::InsertStreamRequest>*)':
reverb/cc/reverb_service_impl.cc:201:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status = table->InsertOrAssign(item); !status.ok()) {
           ^~~~
reverb/cc/reverb_service_impl.cc: In member function 'grpc::Status deepmind::reverb::ReverbServiceImpl::SampleStreamInternal(grpc::ServerContext*, grpc::ServerReaderWriterInterface<deepmind::reverb::SampleStreamResponse, deepmind::reverb::SampleStreamRequest>*)':
reverb/cc/reverb_service_impl.cc:309:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status =
           ^~~~
INFO: From Compiling reverb/cc/rate_limiter.cc:
reverb/cc/rate_limiter.cc: In member function 'std::vector<deepmind::reverb::RateLimiterEvent> deepmind::reverb::RateLimiter::StatsManager::GetEventHistory(absl::lts_2020_09_23::Mutex*, size_t) const':
reverb/cc/rate_limiter.cc:276:7: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
   if (const auto diff = next_event_id_ - min_event_id; diff >= events_.size()) {
       ^~~~~
INFO: From Compiling reverb/cc/table.cc:
reverb/cc/table.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::Table::SampleFlexibleBatch(std::vector<deepmind::reverb::Table::SampledItem>*, int, absl::lts_2020_09_23::Duration)':
reverb/cc/table.cc:227:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status = rate_limiter_->AwaitAndFinalizeSample(&mu_, timeout);
           ^~~~
INFO: From Compiling reverb/cc/reverb_service_impl.cc:
reverb/cc/reverb_service_impl.cc: In member function 'grpc::Status deepmind::reverb::ReverbServiceImpl::InsertStreamInternal(grpc::ServerContext*, grpc::ServerReaderWriterInterface<deepmind::reverb::InsertStreamResponse, deepmind::reverb::InsertStreamRequest>*)':
reverb/cc/reverb_service_impl.cc:201:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status = table->InsertOrAssign(item); !status.ok()) {
           ^~~~
reverb/cc/reverb_service_impl.cc: In member function 'grpc::Status deepmind::reverb::ReverbServiceImpl::SampleStreamInternal(grpc::ServerContext*, grpc::ServerReaderWriterInterface<deepmind::reverb::SampleStreamResponse, deepmind::reverb::SampleStreamRequest>*)':
reverb/cc/reverb_service_impl.cc:309:11: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
       if (auto status =
           ^~~~
INFO: From Compiling reverb/cc/chunker_test.cc:
reverb/cc/chunker_test.cc: In member function 'virtual void deepmind::reverb::{anonymous}::Chunker_ApplyConfigRejectsInvalidOptions_Test::TestBody()':
reverb/cc/chunker_test.cc:655:19: warning: decomposition declaration only available with -std=c++1z or -std=gnu++1z
   for (const auto [max_chunk_length, num_keep_alive_refs] : invalid_options) {
                   ^
INFO: From Compiling reverb/cc/trajectory_writer.cc:
reverb/cc/trajectory_writer.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::TrajectoryWriter::CreateItem(absl::lts_2020_09_23::string_view, double, absl::lts_2020_09_23::Span<const deepmind::reverb::TrajectoryColumn>)':
reverb/cc/trajectory_writer.cc:306:9: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
     if (auto status = trajectory[col_idx].Validate(); !status.ok()) {
         ^~~~
reverb/cc/trajectory_writer.cc: In member function 'absl::lts_2020_09_23::Status deepmind::reverb::TrajectoryWriter::ConfigureChunker(int, const std::shared_ptr<deepmind::reverb::ChunkerOptions>&)':
reverb/cc/trajectory_writer.cc:664:7: warning: init-statement in selection statements only available with -std=c++1z or -std=gnu++1z
   if (auto it = chunkers_.find(column); it != chunkers_.end()) {
       ^~~~
reverb/cc/trajectory_writer.cc: In lambda function:
reverb/cc/trajectory_writer.cc:144:3: warning: control reaches end of non-void function [-Wreturn-type]
   };
   ^
INFO: From Compiling reverb/cc/support/signature.cc:
reverb/cc/support/signature.cc: In lambda function:
reverb/cc/support/signature.cc:179:3: warning: control reaches end of non-void function [-Wreturn-type]
   };
   ^
INFO: From Compiling reverb/cc/support/unbounded_queue_test.cc:
In file included from reverb/cc/support/unbounded_queue_test.cc:15:0:
./reverb/cc/support/unbounded_queue.h: In instantiation of 'deepmind::reverb::internal::UnboundedQueue<T>::UnboundedQueue() [with T = int]':
reverb/cc/support/unbounded_queue_test.cc:29:23:   required from here
./reverb/cc/support/unbounded_queue.h:111:8: warning: 'deepmind::reverb::internal::UnboundedQueue<int>::closed_' will be initialized after [-Wreorder]
   bool closed_ ABSL_GUARDED_BY(mu_);
        ^~~~~~~
./reverb/cc/support/unbounded_queue.h:108:7: warning:   'int deepmind::reverb::internal::UnboundedQueue<int>::size_' [-Wreorder]
   int size_ ABSL_GUARDED_BY(mu_);
       ^~~~~
./reverb/cc/support/unbounded_queue.h:41:12: warning:   when initialized here [-Wreorder]
   explicit UnboundedQueue()
            ^~~~~~~~~~~~~~
INFO: Elapsed time: 1348.327s, Critical Path: 147.80s
INFO: 1435 processes: 1435 linux-sandbox.
INFO: Build completed successfully, 1899 total actions
//reverb/cc:chunk_store_test                                             PASSED in 1.5s
//reverb/cc:chunker_test                                                 PASSED in 11.1s
//reverb/cc:client_test                                                  PASSED in 0.7s
//reverb/cc:rate_limiter_test                                            PASSED in 3.1s
//reverb/cc:reverb_service_impl_test                                     PASSED in 1.3s
//reverb/cc:sampler_test                                                 PASSED in 12.7s
//reverb/cc:table_test                                                   PASSED in 5.4s
//reverb/cc:tensor_compression_test                                      PASSED in 1.6s
//reverb/cc:trajectory_writer_test                                       PASSED in 1.7s
//reverb/cc:writer_test                                                  PASSED in 1.4s
//reverb/cc/platform:net_test                                            PASSED in 0.4s
//reverb/cc/platform:server_test                                         PASSED in 0.5s
//reverb/cc/platform:tfrecord_checkpointer_test                          PASSED in 1.5s
//reverb/cc/platform:thread_test                                         PASSED in 0.7s
//reverb/cc/selectors:fifo_test                                          PASSED in 2.2s
//reverb/cc/selectors:heap_test                                          PASSED in 1.7s
//reverb/cc/selectors:lifo_test                                          PASSED in 1.2s
//reverb/cc/selectors:prioritized_test                                   PASSED in 1.8s
//reverb/cc/selectors:uniform_test                                       PASSED in 2.8s
//reverb/cc/support:cleanup_test                                         PASSED in 0.5s
//reverb/cc/support:intrusive_heap_test                                  PASSED in 0.5s
//reverb/cc/support:periodic_closure_test                                PASSED in 3.1s
//reverb/cc/support:queue_test                                           PASSED in 0.7s
//reverb/cc/support:signature_test                                       PASSED in 0.4s
//reverb/cc/support:trajectory_util_test                                 PASSED in 0.4s
//reverb/cc/support:unbounded_queue_test                                 PASSED in 0.4s

INFO: Build completed successfully, 1899 total actions
```

## Result

```python
ubuntu@nvidia-01:~/Desktop/Projects$ python3
Python 3.6.9 (default, Jan 26 2021, 15:33:00) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import reverb
2021-08-20 21:59:20.352419: I tensorflow/stream_executor/platform/default/dso_loader.cc:53] Successfully opened dynamic library libcudart.so.10.2
>>> server = reverb.Server(tables=[
...     reverb.Table(
...         name='my_table',
...         sampler=reverb.selectors.Uniform(),
...         remover=reverb.selectors.Fifo(),
...         max_size=100,
...         rate_limiter=reverb.rate_limiters.MinSize(1)),
...     ],
...     port=8000
... )
[reverb/cc/platform/tfrecord_checkpointer.cc:150]  Initializing TFRecordCheckpointer in /tmp/tmpn2opir8k.
[reverb/cc/platform/tfrecord_checkpointer.cc:378] Loading latest checkpoint from /tmp/tmpn2opir8k
[reverb/cc/platform/default/server.cc:54] Started replay server on port 8000
>>> client = reverb.Client('localhost:8000')
>>> print(client.server_info())
{'my_table': TableInfo(name='my_table', sampler_options=uniform: true
, remover_options=fifo: true
is_deterministic: true
, max_size=100, max_times_sampled=0, rate_limiter_info=samples_per_insert: 1.0
min_diff: -1.7976931348623157e+308
max_diff: 1.7976931348623157e+308
min_size_to_sample: 1
insert_stats {
  completed_wait_time {
  }
  pending_wait_time {
  }
}
sample_stats {
  completed_wait_time {
  }
  pending_wait_time {
  }
}
, signature=None, current_size=0, num_episodes=0, num_deleted_episodes=0)}
>>> quit()
[reverb/cc/platform/default/server.cc:63] Shutting down replay server
```