### PR TITLE
Fix typo in gen_reverb_ops.py (for import error messages)

### DIFF
--- a/reverb/cc/platform/default/build_rules.bzl
+++ b/reverb/cc/platform/default/build_rules.bzl
@@ -325,7 +325,7 @@ from reverb.platform.default import load_op_library as _load_op_library
 try:
   _reverb_gen_op = _tf.load_op_library(
     _tf.compat.v1.resource_loader.get_path_to_datafile("lib{}_gen_op.so"))
-except tf.errors.NotFoundError as e:
+except _tf.errors.NotFoundError as e:
   _load_op_library.reraise_wrapped_error(e)
 _locals = locals()
 for k in dir(_reverb_gen_op):


### PR DESCRIPTION
The intended error message introduced in 8e194fb (cl/405440707) actually
does not work in OSS, because of a typo. This commit fixes the typo.

FYI, what currently happens:
```
$CONDA_PREFIX/lib/python3.9/site-packages/reverb/cc/ops/gen_reverb_ops.py in <module>
      5   _reverb_gen_op = _tf.load_op_library(
      6     _tf.compat.v1.resource_loader.get_path_to_datafile("libgen_reverb_ops_gen_op.so"))
----> 7 except tf.errors.NotFoundError as e:
      8   _load_op_library.reraise_wrapped_error(e)
      9 _locals = locals()

NameError: name 'tf' is not defined
```

/cc @ebrevdo