### PR TITLE
Fix Python memory allocation error on accessing Table.info

### DIFF
--- a/reverb/pybind.cc
+++ b/reverb/pybind.cc
@@ -284,8 +284,7 @@ PYBIND11_MODULE(libpybind, m) {
           [](Table *table) -> py::bytes {
             // Return a serialized TableInfo proto bytes string.
             return py::bytes(table->info().SerializeAsString());
-          },
-          py::call_guard<py::gil_scoped_release>())
+          })
       .def("__repr__", &Table::DebugString,
            py::call_guard<py::gil_scoped_release>());
 


### PR DESCRIPTION
Fixing the issue found in https://github.com/deepmind/acme/issues/235.

When `PYTHONMALLOC=malloc_debug`, accessing the table.info() will result in 

```
Fatal Python error: Python memory allocator called without holding the GIL
Python runtime state: initialized
```

This PR fixes this issue. I have tested it in my particular use case and the error goes away with this PR's change. However, as I am not very familiar with C++ and pybind I am not entirely sure if this is the correct way to address the problem. I am happy to make further changes to this PR to fix this issue.

BTW, the README.md does not seem to work for building reverb against older version of TensorFlow. I tried building against TF 2.8.0 and it seems to throw a lot of errors. Building against tf-nightly works. The launchpad README also seems to have a similar issue and I have not succeeded in building it against 2.8.0, which is the version currently pinned in dm-acme.
