### PR TITLE
Remove libpython*.so in python-includes [request for comments]

### DIFF
--- a/reverb/cc/platform/default/repo.bzl
+++ b/reverb/cc/platform/default/repo.bzl
@@ -252,7 +252,6 @@ def _python_includes_repo_impl(repo_ctx):
 cc_library(
     name = "python_includes",
     hdrs = glob(["python_includes/**/*.h"]),
-    srcs = ["{}"],
     includes = ["python_includes"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Currently, when the user does not have libpython*.so in system library paths, they will get an error

```
ImportError: libpython3.10.so.1.0: cannot open shared object file: No such file or directory
```

See e.g., https://github.com/deepmind/reverb/issues/95, https://github.com/deepmind/reverb/issues/15, https://github.com/deepmind/acme/issues/47, https://github.com/deepmind/acme/issues/65
This can happen when users use a Python installation such as Anaconda, where the python shared libraries are not installed into a system directory. The current solution is to change LD_LIBRARY_PATH to include the Conda's lib/path. e.g. LD_LIBRARY_PATH=/opt/conda/lib, but this is inconvenient. This PR aims to alleviate the need to change LD_LIBRARY_PATH or install libpython via apt-get.

I have noticed that the current bazel adds the python shared library as a dependency, but it seems that this is perhaps not needed? There is a comment that I do not quite follow.

https://github.com/deepmind/reverb/blob/master/reverb/cc/platform/default/repo.bzl#L246-L248
```python
    # Note, "@python_includes" is a misnomer since we include the
    # libpythonX.Y.so in the srcs, so we can get access to python's various
    # symbols at link time.
```
During compilation time, I would imagine that only the Python headers will be needed, and the symbols should be available from the Python headers. 
Since the python interpreter will load these symbols during runtime, there shouldn't be an issue with symbol lookup. Please let me know if this is not the case since I may not be aware of some of the side effects of not including libpython during build time.
