### PR TITLE
Fix `pip install` on Colab

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -88,6 +88,7 @@
       },
       "outputs": [],
       "source": [
+        "!pip install numpy --upgrade\n",
         "!pip install dm-tree\n",
         "!pip install dm-reverb[tensorflow]"
       ]


### PR DESCRIPTION
This is a very ad-hoc fix for error encountered running tutorial in Colab:

```
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xf
```

I've no idea if this also indicates an issue in the build process to fix (maybe this repo needs [oldest-support-numpy or something, no clue](https://github.com/numpy/numpy/blob/main/doc/source/user/troubleshooting-importerror.rst#c-api-incompatibility)).