### PR TITLE
feat: timeout argument for client.sample

### DIFF
--- a/reverb/cc/sampler.cc
+++ b/reverb/cc/sampler.cc
@@ -208,6 +208,13 @@ class GrpcSamplerWorker : public SamplerWorker {
       }
       context_ = std::make_unique<grpc::ClientContext>();
       context_->set_wait_for_ready(false);
+
+      // Buffer time to account for connection overhead
+      constexpr auto CONNECTION_BUFFER_TIME = std::chrono::milliseconds(200);
+
+      // Setting the deadline for the gRPC context
+      context_->set_deadline(absl::ToChronoTime(absl::Now() + rate_limiter_timeout + CONNECTION_BUFFER_TIME));
+
       stream = stub_->SampleStream(context_.get());
     }
 


### PR DESCRIPTION
## The Details

### resolves
- Fixes: #18 

### Proposed Changes

Similarly to https://github.com/deepmind/reverb/issues/4, it would be useful to be able to back out of sampling without needing to wrap things in a thread or use an executor. I agree that often, you'd want to sample asynchronously to maximize throughput, but there are cases where the predictability and simplicity are preferable even if it comes at the expense of efficiency (e.g., in research). A timeout argument would simplify the synchronous setting without sacrificing safeguards from indefinite waiting.

<!-- TODO: Describe what this Pull Request does.  Include screenshots if applicable. -->

#### Behavior Before Change

The client can indeed get blocked indefinitely if the server crashes or is terminated.

<!--TODO: Image, gif or explanation of behavior before this pull request. -->

#### Behavior After Change

After providing the timeout functionality to the `client.sample` we can set a timeout for the flush operation using the `timeout_ms` argument.